### PR TITLE
fix: normalize LZWBTC coin_type key in COIN_MAP

### DIFF
--- a/sui/navi/src/mainnet/utils.ts
+++ b/sui/navi/src/mainnet/utils.ts
@@ -143,7 +143,7 @@ export const COIN_MAP: CoinMap = {
     "YBTC",
   "0x9d297676e7a4b771ab023291377b2adfaa4938fb9080b8d12430e4b108b836a9::xaum::XAUM":
     "XAUM",
-  "0x0041f9f9344cac094454cd574e333c4fdb132d7bcc9379bcd4aab485b2a63942::wbtc::WBTC":
+  "0x41f9f9344cac094454cd574e333c4fdb132d7bcc9379bcd4aab485b2a63942::wbtc::WBTC":
     "LZWBTC",
   "0x41d587e5336f1c86cad50d38a7136db99333bb9bda91cea4ba69115defeb1402::sui_usde::SUI_USDE":
     "suiUSDe",


### PR DESCRIPTION
The LZWBTC entry had two leading zeros in its address (0x0041f9f9...), but normalizeCoinType strips leading zeros before lookup, causing getCoinSymbolByType to miss and emit `UNKNOWN_32` for WithdrawTreasuryV2.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a single constant key change to align with existing coin-type normalization and avoid misclassifying `LZWBTC` as unknown.
> 
> **Overview**
> Fixes `LZWBTC` symbol resolution by updating its `COIN_MAP` key from a `0x00…`-prefixed address to the normalized `0x…` form, matching `normalizeCoinType` behavior.
> 
> This prevents downstream `getCoinSymbolByType` callers (e.g., treasury/withdraw flows) from falling back to `unknown`/`UNKNOWN_*` for that coin type.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8b58e17971a58c7cbf7a86d3cffc40fbfda575cb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->